### PR TITLE
Change GDAL version

### DIFF
--- a/src/Landscapes/Landis_Landscapes.csproj
+++ b/src/Landscapes/Landis_Landscapes.csproj
@@ -15,6 +15,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>LANDIS-II;Landis;Landscapes</PackageTags>
     <NeutralLanguage>English</NeutralLanguage>
+    <Version>2.0.0</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/RasterIO.Gdal/Landis_RasterIO_Gdal.csproj
+++ b/src/RasterIO.Gdal/Landis_RasterIO_Gdal.csproj
@@ -15,17 +15,20 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>LANDIS-II;Landis;RasterIO;Gdal</PackageTags>
     <NeutralLanguage>English</NeutralLanguage>
+    <Version>2.0.0</Version>
+    <PackageLicenseUrl></PackageLicenseUrl>
+    <PackageId>Landis.RasterIO.Gdal</PackageId>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="GDAL.NET" Version="2.3.1" />
+  </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\api\Landis_SpatialModeling.csproj">
     </ProjectReference>
     <ProjectReference Include="..\RasterIO\Landis_RasterIO.csproj">
     </ProjectReference>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Gdal.Core" Version="1.0.0" />
   </ItemGroup>
   
 </Project>

--- a/src/RasterIO/Landis_RasterIO.csproj
+++ b/src/RasterIO/Landis_RasterIO.csproj
@@ -15,6 +15,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>LANDIS-II;Landis;RasterIO</PackageTags>
     <NeutralLanguage>English</NeutralLanguage>
+    <Version>2.0.0</Version>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/api/Landis_SpatialModeling.csproj
+++ b/src/api/Landis_SpatialModeling.csproj
@@ -13,5 +13,6 @@
     <RepositoryUrl>https://github.com/LANDIS-II-Foundation/Library-Spatial</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>LANDIS-II;Landis;Spatial Modeling</PackageTags>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Switched out GDAL Core for a version of GDAL that works cross platform on x64 architecture. LANDIS-II will now run on Windows Server and Windows 10.