### PR TITLE
Change NuGet Package Version

### DIFF
--- a/src/RasterIO.Gdal/Landis_RasterIO_Gdal.csproj
+++ b/src/RasterIO.Gdal/Landis_RasterIO_Gdal.csproj
@@ -15,7 +15,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>LANDIS-II;Landis;RasterIO;Gdal</PackageTags>
     <NeutralLanguage>English</NeutralLanguage>
-    <Version>2.0.0</Version>
+    <Version>2.1.0</Version>
     <PackageLicenseUrl></PackageLicenseUrl>
     <PackageId>Landis.RasterIO.Gdal</PackageId>
   </PropertyGroup>

--- a/src/RasterIO.Gdal/RasterFactory.cs
+++ b/src/RasterIO.Gdal/RasterFactory.cs
@@ -1,7 +1,7 @@
 
 // Copyright 2010-2011 Green Code LLC
 // All rights reserved.
-// //
+//
 // The copyright holders license this file under the New (3-clause) BSD
 // License (the "License").  You may not use this file except in
 // compliance with the License.  A copy of the License is available at

--- a/src/RasterIO.Gdal/RasterFactory.cs
+++ b/src/RasterIO.Gdal/RasterFactory.cs
@@ -1,7 +1,7 @@
 
 // Copyright 2010-2011 Green Code LLC
 // All rights reserved.
-//
+// //
 // The copyright holders license this file under the New (3-clause) BSD
 // License (the "License").  You may not use this file except in
 // compliance with the License.  A copy of the License is available at


### PR DESCRIPTION
Changed the version of this NuGet package to indicate that the GDAL it uses is a version compatible with any x64 Windows.