### PR TITLE
Geospatial toolbelt implementation take2

### DIFF
--- a/src/Landis_GeoTiff/Dimensions.cs
+++ b/src/Landis_GeoTiff/Dimensions.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Landis_GeoTiff
+{
+    public struct Dimensions
+    {
+        private int rows;
+        private int columns;
+
+        //---------------------------------------------------------------------
+
+        /// <summary>
+        /// Initializes a new instance.
+        /// </summary>
+        /// <exception cref="System.ArgumentException">
+        /// The number of rows or columns is negative.
+        /// </exception>
+        public Dimensions(int rows,
+                          int columns)
+        {
+            if (rows < 0)
+                throw new System.ArgumentException("rows parameter is negative");
+            if (columns < 0)
+                throw new System.ArgumentException("columns parameter is negative");
+            this.rows = rows;
+            this.columns = columns;
+        }
+
+        //---------------------------------------------------------------------
+
+        /// <summary>
+        /// The number of rows.
+        /// </summary>
+        public int Rows
+        {
+            get
+            {
+                return rows;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        /// <summary>
+        /// The number of columns.
+        /// </summary>
+        public int Columns
+        {
+            get
+            {
+                return columns;
+            }
+        }
+
+        //---------------------------------------------------------------------
+
+        /// <summary>
+        /// Tests two sets of dimensions for equality.
+        /// </summary>
+        /// <param name="x">
+        /// First set of dimensions
+        /// </param>
+        /// <param name="y">
+        /// Second set of dimensions
+        /// </param>
+        /// <returns>
+        /// true if the two set of dimensions are equal; false otherwise.
+        /// </returns>
+        public static bool operator ==(Dimensions x,
+                                       Dimensions y)
+        {
+            return (x.rows == y.rows) && (x.columns == y.columns);
+        }
+
+        //---------------------------------------------------------------------
+
+        /// <summary>
+        /// Tests two sets of dimensions for inequality.
+        /// </summary>
+        /// <param name="x">
+        /// First set of dimensions
+        /// </param>
+        /// <param name="y">
+        /// Second set of dimensions
+        /// </param>
+        /// <returns>
+        /// true if the two set of dimensions are not equal; false otherwise.
+        /// </returns>
+        public static bool operator !=(Dimensions x,
+                                       Dimensions y)
+        {
+            return !(x == y);
+        }
+
+        //---------------------------------------------------------------------
+
+        /// <summary>
+        /// Determines whether the specified object equals the current object.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current object.
+        /// </param>
+        /// <returns><b>true</b> if the specified object is equal to the
+        /// current object; otherwise, <b>false</b>.</returns>
+        public override bool Equals(object obj)
+        {
+            //Check for null and compare run-time types.
+            if (obj == null || GetType() != obj.GetType())
+                return false;
+            Dimensions loc = (Dimensions)obj;
+            return this == loc;
+        }
+
+        //---------------------------------------------------------------------
+
+        /// <summary>
+        /// Computes a hash code for the current object.
+        /// </summary>
+        /// <returns>A hash code</returns>
+        public override int GetHashCode()
+        {
+            return (int)(rows ^ columns);
+        }
+
+        //---------------------------------------------------------------------
+
+        /// <summary>
+        /// Returns a string that represents the current object.
+        /// </summary>
+        /// <returns>A string formatted as "# rows by # columns".</returns>
+        public override string ToString()
+        {
+            return string.Format("{0:#,##0} row{1} by {2:#,##0} column{3}",
+                                 rows, (rows == 1 ? "" : "s"),
+                                 columns, (columns == 1 ? "" : "s"));
+        }
+    }
+}

--- a/src/Landis_GeoTiff/IInputRaster.cs
+++ b/src/Landis_GeoTiff/IInputRaster.cs
@@ -1,0 +1,11 @@
+﻿namespace Landis_GeoTiff
+{
+    public interface IInputRaster<T> : System.IDisposable
+        where T : struct
+    {
+        T BufferPixel { get; }
+        T ReadBufferPixel();
+
+        Dimensions Dimensions { get; }
+    }
+}

--- a/src/Landis_GeoTiff/IOutputRaster.cs
+++ b/src/Landis_GeoTiff/IOutputRaster.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Landis_GeoTiff
+{
+    public interface IOutputRaster<T> : System.IDisposable
+        where T : struct
+    {
+        T BufferPixel { get; set; }
+        void WriteBufferPixel();
+
+        Dimensions Dimensions { get; set; }
+
+        public void SaveAs(string fileName);
+    }
+}

--- a/src/Landis_GeoTiff/LandisRaster.cs
+++ b/src/Landis_GeoTiff/LandisRaster.cs
@@ -1,0 +1,91 @@
+﻿using GeoTBelt.GeoTiff;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Landis_GeoTiff
+{
+    public class LandisRaster<T> : IInputRaster<T>, IOutputRaster<T>
+        where T : struct
+    {
+        internal LandisRaster() { }
+
+        protected bool disposed = false;
+        public GeoTiffRaster<T> theRaster { get; internal set; } = null;
+
+        private int index = -1;
+        private T buffPix = default;
+        public T BufferPixel
+        {
+            get { return buffPix; }
+            set { buffPix = value; }
+        }
+
+        protected Dimensions _dimensions = default;
+        public Dimensions Dimensions
+        {
+            get
+            {
+                if (_dimensions == default(Dimensions))
+                {
+                    var rows = theRaster.Grid.rasterRows;
+                    var cols = theRaster.Grid.rasterColumns;
+                    _dimensions =
+                        new Dimensions(rows, cols);
+                }
+                return _dimensions;
+            }
+
+            set { _dimensions = value; }
+        }
+
+        public void SaveAs(string fileName = null)
+        {
+            try
+            {
+                if (fileName is not null)
+                    theRaster.SaveAs(theRaster.fileName);
+                else
+                    theRaster.SaveAs(theRaster.fileName);
+            }
+            catch (IOException)
+            {
+
+            }
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public int Count()
+        {
+            if (theRaster is not null)
+                return theRaster.numRows * theRaster.numColumns;
+            return 0;
+        }
+
+        public T ReadBufferPixel()
+        {
+            if (Count() == 0)
+                return (default);
+
+            index++;
+            if (index >= Count())
+                throw new IndexOutOfRangeException();
+
+            buffPix = theRaster.GetValueAt(index);
+            return buffPix;
+        }
+
+        public void WriteBufferPixel()
+        {
+            if (++index >= Count())
+                throw new IndexOutOfRangeException();
+            theRaster.SetValueAtLinearIndex(BufferPixel, index);
+        }
+
+    }
+}

--- a/src/Landis_GeoTiff/Landis_GeoTiff.csproj
+++ b/src/Landis_GeoTiff/Landis_GeoTiff.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Landis_GeoTiff/Landis_GeoTiff.csproj
+++ b/src/Landis_GeoTiff/Landis_GeoTiff.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="GeoTBelt" Version="0.1.1" />
+  </ItemGroup>
+
 </Project>

--- a/src/Landis_GeoTiff/RasterFactory.cs
+++ b/src/Landis_GeoTiff/RasterFactory.cs
@@ -1,0 +1,40 @@
+﻿using GeoTBelt.GeoTiff;
+using GeoTBelt;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Landis_GeoTiff
+{
+    public static class RasterFactory
+    {
+        public static IInputRaster<T> OpenRaster<T>(string path)
+            where T : struct
+        {
+
+            var localRaster = (GeoTiffRaster<T>)Raster<T>.Load(path);
+
+            LandisRaster<T> workingRaster = new LandisRaster<T>();
+            workingRaster.theRaster = localRaster;
+
+            return (IInputRaster<T>)workingRaster;
+        }
+
+        public static IOutputRaster<T> CreateRaster<T>
+            (string path, Dimensions dimensions)
+            where T : struct
+        {
+            LandisRaster<T> returnRaster = new LandisRaster<T>();
+            returnRaster.theRaster =
+                GeoTiffRaster<T>.MakeNew(path,
+                dimensions.Rows, dimensions.Columns);
+
+            var v = returnRaster.theRaster;
+
+            returnRaster.Dimensions = dimensions;
+            return returnRaster;
+        }
+    }
+}

--- a/src/RasterIO.Gdal/Landis_RasterIO_Gdal.csproj
+++ b/src/RasterIO.Gdal/Landis_RasterIO_Gdal.csproj
@@ -23,8 +23,6 @@
   <ItemGroup>
     <ProjectReference Include="..\api\Landis_SpatialModeling.csproj">
     </ProjectReference>
-    <ProjectReference Include="..\RasterIO\Landis_RasterIO.csproj">
-    </ProjectReference>
   </ItemGroup>
   
   <ItemGroup>

--- a/src/landis-spatial.sln
+++ b/src/landis-spatial.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Landis_SpatialModeling", "a
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Landis_Landscapes", "Landscapes\Landis_Landscapes.csproj", "{1C3CBB5D-CFF2-4234-AD59-24FBBE5779F0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Landis_GeoTiff", "Landis_GeoTiff\Landis_GeoTiff.csproj", "{1629AC4E-7CE3-4933-B56A-CF40D0BE999C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{1C3CBB5D-CFF2-4234-AD59-24FBBE5779F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1C3CBB5D-CFF2-4234-AD59-24FBBE5779F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1C3CBB5D-CFF2-4234-AD59-24FBBE5779F0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1629AC4E-7CE3-4933-B56A-CF40D0BE999C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1629AC4E-7CE3-4933-B56A-CF40D0BE999C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1629AC4E-7CE3-4933-B56A-CF40D0BE999C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1629AC4E-7CE3-4933-B56A-CF40D0BE999C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/landis-spatial.sln
+++ b/src/landis-spatial.sln
@@ -1,15 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27428.2037
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Landis_SpatialModeling", "api\Landis_SpatialModeling.csproj", "{C3BB257A-34F1-4DD2-83D5-69EBDDCD50B1}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Landis_Landscapes", "Landscapes\Landis_Landscapes.csproj", "{1C3CBB5D-CFF2-4234-AD59-24FBBE5779F0}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Landis_RasterIO", "RasterIO\Landis_RasterIO.csproj", "{72EDF418-CF3E-4D23-9161-51510FBAF4EB}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Landis_RasterIO_Gdal", "RasterIO.Gdal\Landis_RasterIO_Gdal.csproj", "{EF6B05AA-EC3F-423B-9E8E-D8A2E188D2F8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -25,14 +21,6 @@ Global
 		{1C3CBB5D-CFF2-4234-AD59-24FBBE5779F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1C3CBB5D-CFF2-4234-AD59-24FBBE5779F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1C3CBB5D-CFF2-4234-AD59-24FBBE5779F0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{72EDF418-CF3E-4D23-9161-51510FBAF4EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{72EDF418-CF3E-4D23-9161-51510FBAF4EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{72EDF418-CF3E-4D23-9161-51510FBAF4EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{72EDF418-CF3E-4D23-9161-51510FBAF4EB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EF6B05AA-EC3F-423B-9E8E-D8A2E188D2F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EF6B05AA-EC3F-423B-9E8E-D8A2E188D2F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EF6B05AA-EC3F-423B-9E8E-D8A2E188D2F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EF6B05AA-EC3F-423B-9E8E-D8A2E188D2F8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This includes the new project, Landis_GeoTiff, which depends on Geospatial Toolbelt from Nuget. It also modifies the .sln so as to remove RasterIO and RasterIO .Gdal. It is on its own branch, Geospatial_Toolbelt_Imp_Take2, which branches from master.